### PR TITLE
Register the required resource providers

### DIFF
--- a/Create_Parallels_DaaS_Prereqs_Azure/Create_Parallels_DaaS_Prereqs_Azure.ps1
+++ b/Create_Parallels_DaaS_Prereqs_Azure/Create_Parallels_DaaS_Prereqs_Azure.ps1
@@ -642,6 +642,17 @@ Catch {
     exit
 }
 
+# Register the required Azure resource providers
+try {
+    Register-AzResourceProvider -ProviderNamespace "Microsoft.Network"
+    Register-AzResourceProvider -ProviderNamespace "Microsoft.Compute"
+}
+Catch {
+    Write-Host "ERROR: trying to register required Azure resource providers"
+    Write-Host $_.Exception.Message
+    exit
+}
+
 # Create a custom role to allow adding and deleting role assinments
 try {
     create-CustomRole -SubscriptionId $selectedSubscriptionID -RoleName "Daas Role Assignment"
@@ -737,22 +748,22 @@ Catch {
     exit
 }
 
-# Add an Azure Keyvault and store the Client Secret in it
-try {
-    $selectedKeyVaultName = new-AzureKeyVaultWithSecret -ResourceGroupName $rgInfra.ResourceGroupName -Location $selectedAzureLocation -SecretValue $secret.SecretText -SecretName "daas-spn-client-secret" -SubsciptionID $selectedSubscriptionID
-}
-Catch {
-    Write-Host "ERROR: trying to create a new Azure KeyVault and adding the client secret"
-    Write-Host $_.Exception.Message
-    exit
-}
-
 # Grant admin consent to an the app registration
 try {
     set-AdminConsent -ApplicationId $app.AppId -TenantId $selectedTenantId
 }
 Catch {
     Write-Host "ERROR: trying to grant admin consent to an the app registration"
+    Write-Host $_.Exception.Message
+    exit
+}
+
+# Add an Azure Keyvault and store the Client Secret in it
+try {
+    $selectedKeyVaultName = new-AzureKeyVaultWithSecret -ResourceGroupName $rgInfra.ResourceGroupName -Location $selectedAzureLocation -SecretValue $secret.SecretText -SecretName "daas-spn-client-secret" -SubsciptionID $selectedSubscriptionID
+}
+Catch {
+    Write-Host "ERROR: trying to create a new Azure KeyVault and adding the client secret"
     Write-Host $_.Exception.Message
     exit
 }


### PR DESCRIPTION
## Changes
- Added Resource Provider registration. Re-running this command on the same subscription is not destructive, it will simply re-register the Resource Provider. This adds new locations (if any) that have been added since the previous registration.
From docs: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types.
- Switched steps to grant admin consent before KV creation. This was necessary because if the Key Vault creation failed (for example, due to a name conflict), the admin consent would not be given automatically and would have to be done manually later.